### PR TITLE
Add user signup API and MAUI login page

### DIFF
--- a/FlashCode.API/Program.cs
+++ b/FlashCode.API/Program.cs
@@ -2,6 +2,7 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddControllers();
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
+builder.Services.AddSingleton<UserService>();
 
 var app = builder.Build();
 

--- a/FlashCode.API/User.cs
+++ b/FlashCode.API/User.cs
@@ -1,0 +1,10 @@
+namespace FlashCode.API;
+
+public class User
+{
+    public string Token { get; set; } = string.Empty;
+    public string FirstName { get; set; } = string.Empty;
+    public string Company { get; set; } = string.Empty;
+    public string Email { get; set; } = string.Empty;
+    public bool AcceptContact { get; set; }
+}

--- a/FlashCode.API/UserService.cs
+++ b/FlashCode.API/UserService.cs
@@ -1,0 +1,46 @@
+using System.Collections.Concurrent;
+
+namespace FlashCode.API;
+
+public class UserService
+{
+    private readonly ConcurrentDictionary<string, User> _users = new();
+
+    public User Register(string? token, string firstName, string company, string email, bool acceptContact)
+    {
+        if (!string.IsNullOrEmpty(token) && _users.TryGetValue(token, out var existingByToken))
+        {
+            existingByToken.FirstName = firstName;
+            existingByToken.Company = company;
+            existingByToken.Email = email;
+            existingByToken.AcceptContact = acceptContact;
+            return existingByToken;
+        }
+
+        var existingByEmail = _users.Values.FirstOrDefault(u => u.Email.Equals(email, StringComparison.OrdinalIgnoreCase));
+        if (existingByEmail != null)
+        {
+            existingByEmail.FirstName = firstName;
+            existingByEmail.Company = company;
+            existingByEmail.AcceptContact = acceptContact;
+            return existingByEmail;
+        }
+
+        var newUser = new User
+        {
+            Token = Guid.NewGuid().ToString(),
+            FirstName = firstName,
+            Company = company,
+            Email = email,
+            AcceptContact = acceptContact
+        };
+        _users[newUser.Token] = newUser;
+        return newUser;
+    }
+
+    public User? GetByToken(string token)
+    {
+        _users.TryGetValue(token, out var user);
+        return user;
+    }
+}

--- a/FlashCode.API/UsersController.cs
+++ b/FlashCode.API/UsersController.cs
@@ -1,0 +1,34 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace FlashCode.API;
+
+[ApiController]
+[Route("[controller]")]
+public class UsersController : ControllerBase
+{
+    private readonly UserService _service;
+
+    public UsersController(UserService service)
+    {
+        _service = service;
+    }
+
+    [HttpPost("register")]
+    public ActionResult<RegisterResponse> Register(RegisterRequest request)
+    {
+        var user = _service.Register(request.Token, request.FirstName, request.Company, request.Email, request.AcceptContact);
+        return Ok(new RegisterResponse(user.Token, user.FirstName, user.Company, user.Email));
+    }
+
+    [HttpGet("me")]
+    public ActionResult<UserDto> GetMe([FromHeader(Name = "X-Token")] string token)
+    {
+        var user = _service.GetByToken(token);
+        if (user == null) return NotFound();
+        return Ok(new UserDto(user.FirstName, user.Company, user.Email, user.AcceptContact));
+    }
+}
+
+public record RegisterRequest(string? Token, string FirstName, string Company, string Email, bool AcceptContact);
+public record RegisterResponse(string Token, string FirstName, string Company, string Email);
+public record UserDto(string FirstName, string Company, string Email, bool AcceptContact);

--- a/FlashCode.Mobile/ApiClient.cs
+++ b/FlashCode.Mobile/ApiClient.cs
@@ -1,0 +1,56 @@
+using System.Net.Http.Json;
+
+namespace FlashCode.Mobile;
+
+public class ApiClient
+{
+    private readonly HttpClient _client;
+
+    public ApiClient()
+    {
+        _client = new HttpClient { BaseAddress = new Uri("http://localhost:5000/") };
+    }
+
+    public async Task<RegisterResponse> RegisterAsync(RegisterRequest request)
+    {
+        var response = await _client.PostAsJsonAsync("users/register", request);
+        response.EnsureSuccessStatusCode();
+        var result = await response.Content.ReadFromJsonAsync<RegisterResponse>();
+        return result ?? throw new InvalidOperationException("Invalid response");
+    }
+
+    public async Task<UserDto> GetUserAsync(string token)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Get, "users/me");
+        request.Headers.Add("X-Token", token);
+        var response = await _client.SendAsync(request);
+        response.EnsureSuccessStatusCode();
+        var result = await response.Content.ReadFromJsonAsync<UserDto>();
+        return result ?? throw new InvalidOperationException("Invalid response");
+    }
+}
+
+public class RegisterRequest
+{
+    public string? Token { get; set; }
+    public string FirstName { get; set; } = string.Empty;
+    public string Company { get; set; } = string.Empty;
+    public string Email { get; set; } = string.Empty;
+    public bool AcceptContact { get; set; }
+}
+
+public class RegisterResponse
+{
+    public string Token { get; set; } = string.Empty;
+    public string FirstName { get; set; } = string.Empty;
+    public string Company { get; set; } = string.Empty;
+    public string Email { get; set; } = string.Empty;
+}
+
+public class UserDto
+{
+    public string FirstName { get; set; } = string.Empty;
+    public string Company { get; set; } = string.Empty;
+    public string Email { get; set; } = string.Empty;
+    public bool AcceptContact { get; set; }
+}

--- a/FlashCode.Mobile/LoginPage.cs
+++ b/FlashCode.Mobile/LoginPage.cs
@@ -1,0 +1,100 @@
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Storage;
+using Microsoft.Maui.Graphics;
+
+namespace FlashCode.Mobile;
+
+public class LoginPage : ContentPage
+{
+    private readonly Entry _firstName = new();
+    private readonly Entry _company = new();
+    private readonly Entry _email = new();
+    private readonly CheckBox _optIn = new();
+    private readonly Button _submit = new() { Text = "Valider" };
+    private readonly Label _error = new() { TextColor = Colors.Red };
+    private readonly ApiClient _api = new();
+
+    public LoginPage()
+    {
+        Title = "FlashCode";
+        Content = new ScrollView
+        {
+            Content = new VerticalStackLayout
+            {
+                Padding = 20,
+                Children =
+                {
+                    new Label { Text = "🎯 Participez au défi FlashCode", FontAttributes = FontAttributes.Bold, HorizontalOptions = LayoutOptions.Center },
+                    new Label { Text = "Prénom :" },
+                    _firstName,
+                    new Label { Text = "Entreprise :" },
+                    _company,
+                    new Label { Text = "Email professionnel :" },
+                    _email,
+                    new HorizontalStackLayout
+                    {
+                        Children =
+                        {
+                            _optIn,
+                            new Label { Text = "J’accepte d’être contacté dans le cadre de ce challenge." }
+                        }
+                    },
+                    new Label { Text = "📩 Vous recevrez un mail uniquement si vous faites partie des gagnants, ou pour recevoir votre bonus de participation." },
+                    _submit,
+                    _error
+                }
+            }
+        };
+
+        _submit.Clicked += OnSubmitClicked;
+    }
+
+    protected override async void OnAppearing()
+    {
+        base.OnAppearing();
+        var token = await SecureStorage.Default.GetAsync("user_token");
+        if (!string.IsNullOrEmpty(token))
+        {
+            try
+            {
+                var user = await _api.GetUserAsync(token);
+                _firstName.Text = user.FirstName;
+                _company.Text = user.Company;
+                _email.Text = user.Email;
+                _optIn.IsChecked = user.AcceptContact;
+            }
+            catch (Exception ex)
+            {
+                _error.Text = ex.Message;
+            }
+        }
+    }
+
+    private async void OnSubmitClicked(object? sender, EventArgs e)
+    {
+        _error.Text = string.Empty;
+        _submit.IsEnabled = false;
+        try
+        {
+            var token = await SecureStorage.Default.GetAsync("user_token");
+            var response = await _api.RegisterAsync(new RegisterRequest
+            {
+                Token = token,
+                FirstName = _firstName.Text ?? string.Empty,
+                Company = _company.Text ?? string.Empty,
+                Email = _email.Text ?? string.Empty,
+                AcceptContact = _optIn.IsChecked
+            });
+            await SecureStorage.Default.SetAsync("user_token", response.Token);
+            await DisplayAlert("Succès", "Inscription réussie", "OK");
+        }
+        catch (Exception ex)
+        {
+            _error.Text = ex.Message;
+        }
+        finally
+        {
+            _submit.IsEnabled = true;
+        }
+    }
+}

--- a/FlashCode.Mobile/Program.cs
+++ b/FlashCode.Mobile/Program.cs
@@ -1,5 +1,6 @@
 using Microsoft.Maui;
 using Microsoft.Maui.Hosting;
+using Microsoft.Maui.Controls;
 
 var builder = MauiApp.CreateBuilder();
 builder.UseMauiApp<App>();
@@ -7,9 +8,10 @@ builder.UseMauiApp<App>();
 var app = builder.Build();
 app.Run();
 
-public class App : Application
+class App : Application
 {
-    protected override void OnLaunched(LaunchActivatedEventArgs args)
+    public App()
     {
+        MainPage = new LoginPage();
     }
 }


### PR DESCRIPTION
## Summary
- implement in-memory user service and controller for token-based signup
- add MAUI login page using SecureStorage and API calls
- create simple API client for the mobile app

## Testing
- `dotnet build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685c0dca2f9c8333b98c9949ac0c833f