### PR TITLE
Add Identity with JWT login

### DIFF
--- a/FlashCode.API/Controllers/AccountController.cs
+++ b/FlashCode.API/Controllers/AccountController.cs
@@ -1,0 +1,63 @@
+using FlashCode.API.Models;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.IdentityModel.Tokens;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+
+namespace FlashCode.API.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class AccountController : ControllerBase
+    {
+        private readonly UserManager<IdentityUser> _userManager;
+        private readonly IConfiguration _configuration;
+
+        public AccountController(UserManager<IdentityUser> userManager, IConfiguration configuration)
+        {
+            _userManager = userManager;
+            _configuration = configuration;
+        }
+
+        [HttpPost("login")]
+        public async Task<IActionResult> Login([FromBody] LoginDto model)
+        {
+            var user = await _userManager.FindByNameAsync(model.Username);
+            if (user != null && await _userManager.CheckPasswordAsync(user, model.Password))
+            {
+                var authClaims = new List<Claim>
+                {
+                    new Claim(ClaimTypes.Name, user.UserName!),
+                    new Claim(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString())
+                };
+
+                var token = new JwtSecurityToken(
+                    issuer: _configuration["Jwt:Issuer"],
+                    audience: _configuration["Jwt:Audience"],
+                    expires: DateTime.UtcNow.AddHours(1),
+                    claims: authClaims,
+                    signingCredentials: new SigningCredentials(
+                        new SymmetricSecurityKey(Encoding.UTF8.GetBytes(_configuration["Jwt:Key"]!)),
+                        SecurityAlgorithms.HmacSha256)
+                );
+
+                return Ok(new { token = new JwtSecurityTokenHandler().WriteToken(token) });
+            }
+            return Unauthorized();
+        }
+
+        [HttpPost("register")]
+        public async Task<IActionResult> Register([FromBody] RegisterDto model)
+        {
+            var user = new IdentityUser { UserName = model.Username, Email = model.Email };
+            var result = await _userManager.CreateAsync(user, model.Password);
+            if (result.Succeeded)
+            {
+                return Ok();
+            }
+            return BadRequest(result.Errors);
+        }
+    }
+}

--- a/FlashCode.API/Data/ApplicationDbContext.cs
+++ b/FlashCode.API/Data/ApplicationDbContext.cs
@@ -1,0 +1,13 @@
+using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
+
+namespace FlashCode.API.Data
+{
+    public class ApplicationDbContext : IdentityDbContext
+    {
+        public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options)
+            : base(options)
+        {
+        }
+    }
+}

--- a/FlashCode.API/FlashCode.API.csproj
+++ b/FlashCode.API/FlashCode.API.csproj
@@ -8,6 +8,9 @@
 
   <ItemGroup>
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
   </ItemGroup>
 
 </Project>

--- a/FlashCode.API/Models/LoginDto.cs
+++ b/FlashCode.API/Models/LoginDto.cs
@@ -1,0 +1,8 @@
+namespace FlashCode.API.Models
+{
+    public class LoginDto
+    {
+        public string Username { get; set; } = string.Empty;
+        public string Password { get; set; } = string.Empty;
+    }
+}

--- a/FlashCode.API/Models/RegisterDto.cs
+++ b/FlashCode.API/Models/RegisterDto.cs
@@ -1,0 +1,9 @@
+namespace FlashCode.API.Models
+{
+    public class RegisterDto
+    {
+        public string Username { get; set; } = string.Empty;
+        public string Email { get; set; } = string.Empty;
+        public string Password { get; set; } = string.Empty;
+    }
+}

--- a/FlashCode.API/Program.cs
+++ b/FlashCode.API/Program.cs
@@ -1,6 +1,39 @@
+using FlashCode.API.Data;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.IdentityModel.Tokens;
+using System.Text;
+
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
+
+builder.Services.AddDbContext<ApplicationDbContext>(options =>
+    options.UseInMemoryDatabase("FlashCode"));
+
+builder.Services.AddIdentity<IdentityUser, IdentityRole>()
+    .AddEntityFrameworkStores<ApplicationDbContext>()
+    .AddDefaultTokenProviders();
+
+builder.Services.AddAuthentication(options =>
+    {
+        options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
+        options.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
+    })
+    .AddJwtBearer(options =>
+    {
+        options.TokenValidationParameters = new TokenValidationParameters
+        {
+            ValidateIssuer = true,
+            ValidateAudience = true,
+            ValidateLifetime = true,
+            ValidateIssuerSigningKey = true,
+            ValidIssuer = builder.Configuration["Jwt:Issuer"],
+            ValidAudience = builder.Configuration["Jwt:Audience"],
+            IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(builder.Configuration["Jwt:Key"]!))
+        };
+    });
 
 builder.Services.AddControllers();
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
@@ -18,6 +51,7 @@ if (app.Environment.IsDevelopment())
 
 app.UseHttpsRedirection();
 
+app.UseAuthentication();
 app.UseAuthorization();
 
 app.MapControllers();

--- a/FlashCode.API/appsettings.Development.json
+++ b/FlashCode.API/appsettings.Development.json
@@ -4,5 +4,10 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "Jwt": {
+    "Key": "SuperSecretKey123456",
+    "Issuer": "FlashCodeAPI",
+    "Audience": "FlashCodeAPI"
   }
 }

--- a/FlashCode.API/appsettings.json
+++ b/FlashCode.API/appsettings.json
@@ -6,4 +6,9 @@
     }
   },
   "AllowedHosts": "*"
+  ,"Jwt": {
+    "Key": "SuperSecretKey123456",
+    "Issuer": "FlashCodeAPI",
+    "Audience": "FlashCodeAPI"
+  }
 }

--- a/FlashCode.Dashboard/Controllers/AccountController.cs
+++ b/FlashCode.Dashboard/Controllers/AccountController.cs
@@ -1,0 +1,44 @@
+using FlashCode.Dashboard.Models;
+using Microsoft.AspNetCore.Mvc;
+using System.Net.Http.Json;
+
+namespace FlashCode.Dashboard.Controllers
+{
+    public class AccountController : Controller
+    {
+        private readonly IHttpClientFactory _factory;
+        private readonly IConfiguration _configuration;
+
+        public AccountController(IHttpClientFactory factory, IConfiguration configuration)
+        {
+            _factory = factory;
+            _configuration = configuration;
+        }
+
+        [HttpGet]
+        public IActionResult Login()
+        {
+            return View();
+        }
+
+        [HttpPost]
+        public async Task<IActionResult> Login(LoginViewModel model)
+        {
+            if (!ModelState.IsValid)
+                return View(model);
+
+            var client = _factory.CreateClient();
+            var apiUrl = _configuration["Api:BaseUrl"] + "/api/account/login";
+            var response = await client.PostAsJsonAsync(apiUrl, model);
+            if (response.IsSuccessStatusCode)
+            {
+                var result = await response.Content.ReadFromJsonAsync<LoginResult>();
+                HttpContext.Session.SetString("jwt", result!.Token);
+                return RedirectToAction("Index", "Home");
+            }
+
+            ModelState.AddModelError(string.Empty, "Invalid login attempt.");
+            return View(model);
+        }
+    }
+}

--- a/FlashCode.Dashboard/Models/LoginViewModel.cs
+++ b/FlashCode.Dashboard/Models/LoginViewModel.cs
@@ -1,0 +1,13 @@
+namespace FlashCode.Dashboard.Models
+{
+    public class LoginViewModel
+    {
+        public string Username { get; set; } = string.Empty;
+        public string Password { get; set; } = string.Empty;
+    }
+
+    public class LoginResult
+    {
+        public string Token { get; set; } = string.Empty;
+    }
+}

--- a/FlashCode.Dashboard/Program.cs
+++ b/FlashCode.Dashboard/Program.cs
@@ -2,6 +2,8 @@ var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
 builder.Services.AddControllersWithViews();
+builder.Services.AddSession();
+builder.Services.AddHttpClient();
 
 var app = builder.Build();
 
@@ -18,6 +20,7 @@ app.UseStaticFiles();
 
 app.UseRouting();
 
+app.UseSession();
 app.UseAuthorization();
 
 app.MapControllerRoute(

--- a/FlashCode.Dashboard/Views/Account/Login.cshtml
+++ b/FlashCode.Dashboard/Views/Account/Login.cshtml
@@ -1,0 +1,14 @@
+@model FlashCode.Dashboard.Models.LoginViewModel
+
+<h2>Login</h2>
+<form asp-action="Login" method="post">
+    <div class="mb-3">
+        <label asp-for="Username" class="form-label"></label>
+        <input asp-for="Username" class="form-control" />
+    </div>
+    <div class="mb-3">
+        <label asp-for="Password" class="form-label"></label>
+        <input asp-for="Password" type="password" class="form-control" />
+    </div>
+    <button type="submit" class="btn btn-primary">Login</button>
+</form>

--- a/FlashCode.Dashboard/Views/Shared/_Layout.cshtml
+++ b/FlashCode.Dashboard/Views/Shared/_Layout.cshtml
@@ -25,6 +25,9 @@
                         <li class="nav-item">
                             <a class="nav-link text-dark" asp-area="" asp-controller="Home" asp-action="Privacy">Privacy</a>
                         </li>
+                        <li class="nav-item">
+                            <a class="nav-link text-dark" asp-area="" asp-controller="Account" asp-action="Login">Login</a>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/FlashCode.Dashboard/appsettings.Development.json
+++ b/FlashCode.Dashboard/appsettings.Development.json
@@ -4,5 +4,8 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "Api": {
+    "BaseUrl": "https://localhost:5001"
   }
 }

--- a/FlashCode.Dashboard/appsettings.json
+++ b/FlashCode.Dashboard/appsettings.json
@@ -6,4 +6,7 @@
     }
   },
   "AllowedHosts": "*"
+  ,"Api": {
+    "BaseUrl": "https://localhost:5001"
+  }
 }

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 This repository contains the **FlashCode** solution for Visual Studio 2022. The solution includes three projects:
 
-- **FlashCode.API** – an ASP.NET Core API project configured with Identity.
-- **FlashCode.Dashboard** – an ASP.NET Core MVC web application.
+- **FlashCode.API** – an ASP.NET Core API project configured with Entity Framework and ASP.NET Identity issuing JWT tokens.
+- **FlashCode.Dashboard** – an ASP.NET Core MVC web application with a login page that authenticates against the API using JWT.
 - **FlashCode.Mobile** – a .NET MAUI application targeting .NET 8.
 
 Each project can be opened and built from Visual Studio 2022 using the `FlashCode.sln` solution file.


### PR DESCRIPTION
## Summary
- configure API with Entity Framework, Identity and JWT authentication
- add account controller to issue JWT tokens
- add login page in dashboard project that calls the API
- wire up session and http client in dashboard
- document new login capabilities

## Testing
- `dotnet test FlashCode.sln` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685c11d4b74c8333b78d28969a416805