### PR TITLE
Implement mobile user registration

### DIFF
--- a/FlashCode.API/Controllers/AccountController.cs
+++ b/FlashCode.API/Controllers/AccountController.cs
@@ -1,10 +1,12 @@
 using FlashCode.API.Models;
+using FlashCode.API.Models.Entities;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.IdentityModel.Tokens;
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using System.Text;
+using System.Linq;
 
 namespace FlashCode.API.Controllers
 {
@@ -12,10 +14,10 @@ namespace FlashCode.API.Controllers
     [Route("api/[controller]")]
     public class AccountController : ControllerBase
     {
-        private readonly UserManager<IdentityUser> _userManager;
+        private readonly UserManager<ApplicationUser> _userManager;
         private readonly IConfiguration _configuration;
 
-        public AccountController(UserManager<IdentityUser> userManager, IConfiguration configuration)
+        public AccountController(UserManager<ApplicationUser> userManager, IConfiguration configuration)
         {
             _userManager = userManager;
             _configuration = configuration;
@@ -51,13 +53,64 @@ namespace FlashCode.API.Controllers
         [HttpPost("register")]
         public async Task<IActionResult> Register([FromBody] RegisterDto model)
         {
-            var user = new IdentityUser { UserName = model.Username, Email = model.Email };
+            var user = new ApplicationUser { UserName = model.Username, Email = model.Email };
             var result = await _userManager.CreateAsync(user, model.Password);
             if (result.Succeeded)
             {
                 return Ok();
             }
             return BadRequest(result.Errors);
+        }
+
+        [HttpPost("mobile/register")]
+        public async Task<IActionResult> RegisterMobile([FromBody] MobileRegisterDto model)
+        {
+            ApplicationUser? user = null;
+            if (!string.IsNullOrWhiteSpace(model.Token))
+            {
+                user = _userManager.Users.FirstOrDefault(u => u.MobileToken == model.Token);
+                if (user == null)
+                    return BadRequest("Invalid token");
+            }
+            else
+            {
+                user = _userManager.Users.FirstOrDefault(u => u.Email == model.Email);
+                if (user != null)
+                    return BadRequest("User already exists");
+                user = new ApplicationUser
+                {
+                    UserName = model.Email,
+                    Email = model.Email,
+                    MobileToken = Guid.NewGuid().ToString()
+                };
+                var createResult = await _userManager.CreateAsync(user);
+                if (!createResult.Succeeded)
+                    return BadRequest("Unable to create user");
+            }
+
+            user.FirstName = model.FirstName;
+            user.Company = model.Company;
+            user.AcceptContact = model.AcceptContact;
+            user.Email = model.Email;
+            await _userManager.UpdateAsync(user);
+
+            return Ok(new TokenResult { Token = user.MobileToken });
+        }
+
+        [HttpGet("mobile/profile")]
+        public IActionResult GetMobileProfile([FromQuery] string token)
+        {
+            var user = _userManager.Users.FirstOrDefault(u => u.MobileToken == token);
+            if (user == null)
+                return NotFound();
+
+            return Ok(new MobileProfileDto
+            {
+                FirstName = user.FirstName ?? string.Empty,
+                Company = user.Company ?? string.Empty,
+                Email = user.Email ?? string.Empty,
+                AcceptContact = user.AcceptContact
+            });
         }
     }
 }

--- a/FlashCode.API/Data/ApplicationDbContext.cs
+++ b/FlashCode.API/Data/ApplicationDbContext.cs
@@ -1,9 +1,10 @@
 using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
+using FlashCode.API.Models.Entities;
 
 namespace FlashCode.API.Data
 {
-    public class ApplicationDbContext : IdentityDbContext
+    public class ApplicationDbContext : IdentityDbContext<ApplicationUser>
     {
         public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options)
             : base(options)

--- a/FlashCode.API/Models/Entities/ApplicationUser.cs
+++ b/FlashCode.API/Models/Entities/ApplicationUser.cs
@@ -1,0 +1,12 @@
+using Microsoft.AspNetCore.Identity;
+
+namespace FlashCode.API.Models.Entities
+{
+    public class ApplicationUser : IdentityUser
+    {
+        public string? FirstName { get; set; }
+        public string? Company { get; set; }
+        public bool AcceptContact { get; set; }
+        public string MobileToken { get; set; } = string.Empty;
+    }
+}

--- a/FlashCode.API/Models/MobileProfileDto.cs
+++ b/FlashCode.API/Models/MobileProfileDto.cs
@@ -1,0 +1,10 @@
+namespace FlashCode.API.Models
+{
+    public class MobileProfileDto
+    {
+        public string FirstName { get; set; } = string.Empty;
+        public string Company { get; set; } = string.Empty;
+        public string Email { get; set; } = string.Empty;
+        public bool AcceptContact { get; set; }
+    }
+}

--- a/FlashCode.API/Models/MobileRegisterDto.cs
+++ b/FlashCode.API/Models/MobileRegisterDto.cs
@@ -1,0 +1,11 @@
+namespace FlashCode.API.Models
+{
+    public class MobileRegisterDto
+    {
+        public string? Token { get; set; }
+        public string FirstName { get; set; } = string.Empty;
+        public string Company { get; set; } = string.Empty;
+        public string Email { get; set; } = string.Empty;
+        public bool AcceptContact { get; set; }
+    }
+}

--- a/FlashCode.API/Models/TokenResult.cs
+++ b/FlashCode.API/Models/TokenResult.cs
@@ -1,0 +1,7 @@
+namespace FlashCode.API.Models
+{
+    public class TokenResult
+    {
+        public string Token { get; set; } = string.Empty;
+    }
+}

--- a/FlashCode.API/Program.cs
+++ b/FlashCode.API/Program.cs
@@ -1,4 +1,5 @@
 using FlashCode.API.Data;
+using FlashCode.API.Models.Entities;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
@@ -12,7 +13,7 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddDbContext<ApplicationDbContext>(options =>
     options.UseInMemoryDatabase("FlashCode"));
 
-builder.Services.AddIdentity<IdentityUser, IdentityRole>()
+builder.Services.AddIdentity<ApplicationUser, IdentityRole>()
     .AddEntityFrameworkStores<ApplicationDbContext>()
     .AddDefaultTokenProviders();
 

--- a/FlashCode.Mobile/MainPage.xaml
+++ b/FlashCode.Mobile/MainPage.xaml
@@ -1,36 +1,24 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="FlashCode.Mobile.MainPage">
-
     <ScrollView>
-        <VerticalStackLayout
-            Padding="30,0"
-            Spacing="25">
-            <Image
-                Source="dotnet_bot.png"
-                HeightRequest="185"
-                Aspect="AspectFit"
-                SemanticProperties.Description="dot net bot in a race car number eight" />
-
-            <Label
-                Text="Hello, World!"
-                Style="{StaticResource Headline}"
-                SemanticProperties.HeadingLevel="Level1" />
-
-            <Label
-                Text="Welcome to &#10;.NET Multi-platform App UI"
-                Style="{StaticResource SubHeadline}"
-                SemanticProperties.HeadingLevel="Level2"
-                SemanticProperties.Description="Welcome to dot net Multi platform App U I" />
-
-            <Button
-                x:Name="CounterBtn"
-                Text="Click me" 
-                SemanticProperties.Hint="Counts the number of times you click"
-                Clicked="OnCounterClicked"
-                HorizontalOptions="Fill" />
+        <VerticalStackLayout Padding="30" Spacing="15">
+            <Label Text="🎯 Participez au défi FlashCode"
+                   FontSize="20"
+                   FontAttributes="Bold" />
+            <Label Text="Prénom :" />
+            <Entry x:Name="FirstNameEntry" />
+            <Label Text="Entreprise :" />
+            <Entry x:Name="CompanyEntry" />
+            <Label Text="Email professionnel :" />
+            <Entry x:Name="EmailEntry" Keyboard="Email" />
+            <StackLayout Orientation="Horizontal" Spacing="10">
+                <CheckBox x:Name="ContactCheckbox" />
+                <Label Text="J’accepte d’être contacté dans le cadre de ce challenge." VerticalOptions="Center" />
+            </StackLayout>
+            <Button Text="Valider" Clicked="OnSubmit" />
+            <Label Text="📩 Vous recevrez un mail uniquement si vous faites partie des gagnants, ou pour recevoir votre bonus de participation." FontSize="12" />
         </VerticalStackLayout>
     </ScrollView>
-
 </ContentPage>

--- a/FlashCode.Mobile/MainPage.xaml.cs
+++ b/FlashCode.Mobile/MainPage.xaml.cs
@@ -1,25 +1,59 @@
-﻿namespace FlashCode.Mobile
+using FlashCode.Mobile.Models;
+using FlashCode.Mobile.Services;
+using Microsoft.Maui.Storage;
+
+namespace FlashCode.Mobile
 {
     public partial class MainPage : ContentPage
     {
-        int count = 0;
+        private readonly RegistrationService _service;
+        private const string TokenKey = "user_token";
 
         public MainPage()
         {
             InitializeComponent();
+            _service = Application.Current!.Services.GetService<RegistrationService>()!;
         }
 
-        private void OnCounterClicked(object sender, EventArgs e)
+        protected override async void OnAppearing()
         {
-            count++;
+            base.OnAppearing();
+            var token = await SecureStorage.Default.GetAsync(TokenKey);
+            if (!string.IsNullOrEmpty(token))
+            {
+                var profile = await _service.GetProfileAsync(token);
+                if (profile != null)
+                {
+                    FirstNameEntry.Text = profile.FirstName;
+                    CompanyEntry.Text = profile.Company;
+                    EmailEntry.Text = profile.Email;
+                    ContactCheckbox.IsChecked = profile.AcceptContact;
+                }
+            }
+        }
 
-            if (count == 1)
-                CounterBtn.Text = $"Clicked {count} time";
+        private async void OnSubmit(object sender, EventArgs e)
+        {
+            var token = await SecureStorage.Default.GetAsync(TokenKey);
+            var dto = new MobileRegisterDto
+            {
+                Token = token,
+                FirstName = FirstNameEntry.Text ?? string.Empty,
+                Company = CompanyEntry.Text ?? string.Empty,
+                Email = EmailEntry.Text ?? string.Empty,
+                AcceptContact = ContactCheckbox.IsChecked
+            };
+
+            var result = await _service.RegisterAsync(dto);
+            if (result.Success)
+            {
+                await SecureStorage.Default.SetAsync(TokenKey, result.Token);
+                await DisplayAlert("Succès", "Inscription enregistrée", "OK");
+            }
             else
-                CounterBtn.Text = $"Clicked {count} times";
-
-            SemanticScreenReader.Announce(CounterBtn.Text);
+            {
+                await DisplayAlert("Erreur", result.Error ?? "Erreur inconnue", "OK");
+            }
         }
     }
-
 }

--- a/FlashCode.Mobile/MainPage.xaml.cs
+++ b/FlashCode.Mobile/MainPage.xaml.cs
@@ -12,7 +12,7 @@ namespace FlashCode.Mobile
         public MainPage()
         {
             InitializeComponent();
-            _service = Application.Current!.Services.GetService<RegistrationService>()!;
+            _service = Application.Current!.Handler.MauiContext.Services.GetService<RegistrationService>()!; // Update this line
         }
 
         protected override async void OnAppearing()

--- a/FlashCode.Mobile/MauiProgram.cs
+++ b/FlashCode.Mobile/MauiProgram.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging;
+using FlashCode.Mobile.Services;
 
 namespace FlashCode.Mobile
 {
@@ -14,6 +15,9 @@ namespace FlashCode.Mobile
                     fonts.AddFont("OpenSans-Regular.ttf", "OpenSansRegular");
                     fonts.AddFont("OpenSans-Semibold.ttf", "OpenSansSemibold");
                 });
+
+            builder.Services.AddSingleton(sp => new HttpClient { BaseAddress = new Uri("https://localhost:5001") });
+            builder.Services.AddSingleton<RegistrationService>();
 
 #if DEBUG
     		builder.Logging.AddDebug();

--- a/FlashCode.Mobile/Models/MobileProfileDto.cs
+++ b/FlashCode.Mobile/Models/MobileProfileDto.cs
@@ -1,0 +1,10 @@
+namespace FlashCode.Mobile.Models
+{
+    public class MobileProfileDto
+    {
+        public string FirstName { get; set; } = string.Empty;
+        public string Company { get; set; } = string.Empty;
+        public string Email { get; set; } = string.Empty;
+        public bool AcceptContact { get; set; }
+    }
+}

--- a/FlashCode.Mobile/Models/MobileRegisterDto.cs
+++ b/FlashCode.Mobile/Models/MobileRegisterDto.cs
@@ -1,0 +1,11 @@
+namespace FlashCode.Mobile.Models
+{
+    public class MobileRegisterDto
+    {
+        public string? Token { get; set; }
+        public string FirstName { get; set; } = string.Empty;
+        public string Company { get; set; } = string.Empty;
+        public string Email { get; set; } = string.Empty;
+        public bool AcceptContact { get; set; }
+    }
+}

--- a/FlashCode.Mobile/Models/TokenResult.cs
+++ b/FlashCode.Mobile/Models/TokenResult.cs
@@ -1,0 +1,7 @@
+namespace FlashCode.Mobile.Models
+{
+    public class TokenResult
+    {
+        public string Token { get; set; } = string.Empty;
+    }
+}

--- a/FlashCode.Mobile/Services/RegistrationService.cs
+++ b/FlashCode.Mobile/Services/RegistrationService.cs
@@ -1,0 +1,38 @@
+using FlashCode.Mobile.Models;
+using System.Net.Http.Json;
+
+namespace FlashCode.Mobile.Services
+{
+    public class RegistrationService
+    {
+        private readonly HttpClient _client;
+        private const string RegisterUrl = "/api/account/mobile/register";
+        private const string ProfileUrl = "/api/account/mobile/profile";
+
+        public RegistrationService(HttpClient client)
+        {
+            _client = client;
+        }
+
+        public async Task<(bool Success, string Token, string? Error)> RegisterAsync(MobileRegisterDto dto)
+        {
+            var response = await _client.PostAsJsonAsync(RegisterUrl, dto);
+            if (response.IsSuccessStatusCode)
+            {
+                var result = await response.Content.ReadFromJsonAsync<TokenResult>();
+                return (true, result!.Token, null);
+            }
+            return (false, string.Empty, await response.Content.ReadAsStringAsync());
+        }
+
+        public async Task<MobileProfileDto?> GetProfileAsync(string token)
+        {
+            var response = await _client.GetAsync($"{ProfileUrl}?token={token}");
+            if (response.IsSuccessStatusCode)
+            {
+                return await response.Content.ReadFromJsonAsync<MobileProfileDto>();
+            }
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `ApplicationUser` with mobile fields
- configure Identity to use `ApplicationUser`
- implement mobile registration and profile endpoints
- create MAUI registration form and service

## Testing
- `dotnet build FlashCode.API/FlashCode.API.csproj -clp:ErrorsOnly` *(fails: command not found)*
- `dotnet build FlashCode.sln -clp:ErrorsOnly` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c1852d5948333a8416758d3d1496d